### PR TITLE
A bit more accurate wording about `a` element

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ Text-level semantics
 
 ### Don't split same link that can be grouped
 
-`a` element can wrap all elements (except `a` element itself).
+`a` element can wrap almost all elements (except interactive elements like form controls and `a` element itself).
 
 Bad:
 


### PR DESCRIPTION
Saying that `a` element can contain all elements except `a` itself is kind of oversimplification. The spec allows it to contain 'flow content', [but not 'interactive content'](https://html.spec.whatwg.org/multipage/semantics.html#the-a-element), and 'interactive content' [includes](https://html.spec.whatwg.org/multipage/dom.html#interactive-content) also form controls and labels, multimedia players etc. I suggest the text that doesn't imply that one can nest, e.g., a form control inside `a` element.