### PR TITLE
Drop `version` attribute from SVG code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,13 +317,13 @@ SVG and MathML can be used directly in an HTML5 document.
 
 Bad:
 
-    <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+    <svg xmlns="http://www.w3.org/2000/svg">
       ...
     </svg>
 
 Good:
 
-    <svg version="1.1">
+    <svg>
       ...
     </svg>
 


### PR DESCRIPTION
A SVG code example of spec does not have `version` attribute. So, drop
it for simplicity.

This resolves #34