### PR TITLE
Added for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Good:
 
 ### Don’t use character references as much as possible<span id="dont-use-character-references-as-much-as-possible"></span>
 
-If you write an HTML document with UTF-8, almost all characters (including
-Emoji) can be write directly.
+If you write an HTML document with UTF-8 encoding, almost all characters (including
+Emojis) can be written directly.
 
 Bad:
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For writing maintainable and scalable HTML documents
 
 ### Start with DOCTYPE<span id="start-with-doctype"></span>
 
-DOCTYPE is required for activating standard mode.
+DOCTYPE is required for activating a browser's "full standards" HTML rendering mode.
 
 Bad:
 


### PR DESCRIPTION
- Made the DOCTYPE tag description more specific, so people wanting to learn more about it can search for "full standards" and other modes.
- Added "encoding" to "UTF-8" for clarity
- Fixed some grammar