### PR TITLE
Fix usage of absolute where relative should be

### DIFF
--- a/README.md
+++ b/README.md
@@ -1526,9 +1526,9 @@ Good:
     </html>
 
 
-### Use absolute path for internal links
+### Use relative path for internal links
 
-An absolute path works better on your localhost without internet connection.
+An relative path works better on your localhost without internet connection.
 
 Bad:
 


### PR DESCRIPTION
### Problem
The example in "Use absolute path for internal links" section represents absolute path to be a bad practice but the heading and the text of the section say otherwise. Also, for internal links relative path is better as the protocol and domain name can be omitted as they already match the site's and the file can be located based on where it's found relative to the current document.

### Fix
I've made changes by replacing absolute with relative in the section.

### More clarification
In case you meant absolute path as what is called absolute path in terms of Linux (starting with / which is root) I think it should use relative instead of absolute in that sense that it is a relative path on the web based on document root of the website. Using absolute in this sense would only confuse learners new to HTML who still don't know much about Linux filesystem.